### PR TITLE
LOTImageCache: Rename methods in order to avoid Non-public API calls.

### DIFF
--- a/lottie-ios/Classes/AnimatableLayers/LOTLayerContainer.m
+++ b/lottie-ios/Classes/AnimatableLayers/LOTLayerContainer.m
@@ -151,10 +151,10 @@
         
       id<LOTImageCache> imageCache = [LOTCacheProvider imageCache];
       if (imageCache) {
-        image = [imageCache imageForKey:imagePath];
+        image = [imageCache cachedImageForKey:imagePath];
         if (!image) {
           image = [UIImage imageWithContentsOfFile:imagePath];
-          [imageCache setImage:image forKey:imagePath];
+          [imageCache setCachedImage:image forKey:imagePath];
         }
       } else {
         image = [UIImage imageWithContentsOfFile:imagePath];

--- a/lottie-ios/Classes/PublicHeaders/LOTCacheProvider.h
+++ b/lottie-ios/Classes/PublicHeaders/LOTCacheProvider.h
@@ -32,8 +32,8 @@
 @protocol LOTImageCache <NSObject>
 
 @required
-- (LOTImage *)imageForKey:(NSString *)key;
-- (void)setImage:(LOTImage *)image forKey:(NSString *)key;
+- (LOTImage *)cachedImageForKey:(NSString *)key;
+- (void)setCachedImage:(LOTImage *)image forKey:(NSString *)key;
 
 @end
 


### PR DESCRIPTION
According to Apple's policies, apps cannot use the non-public
selectors imageForKey: and setImage:forKey:. Thus, the methods
signature must change.